### PR TITLE
Optimize allocations with thisrc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "LGPL-3.0",
     "require": {
         "php": ">=7.2.0",
-        "php-64bit": "*"
+        "php-64bit": "*",
+		"ext-thisrc": "0.1.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.25",

--- a/src/Vector3.php
+++ b/src/Vector3.php
@@ -103,11 +103,19 @@ class Vector3{
 	 * @param int|float $z
 	 */
 	public function add($x, $y, $z) : Vector3{
-		return new Vector3($this->x + $x, $this->y + $y, $this->z + $z);
+		$uniq = thisuniq();
+		$uniq->x += $x;
+		$uniq->y += $y;
+		$uniq->z += $z;
+		return $uniq;
 	}
 
 	public function addVector(Vector3 $v) : Vector3{
-		return $this->add($v->x, $v->y, $v->z);
+		$uniq = thisuniq();
+		$uniq->x += $v->x;
+		$uniq->y += $v->y;
+		$uniq->z += $v->z;
+		return $uniq;
 	}
 
 	/**
@@ -122,101 +130,154 @@ class Vector3{
 	 * @param int|float $z
 	 */
 	public function subtract($x, $y, $z) : Vector3{
-		return $this->add(-$x, -$y, -$z);
+		$uniq = thisuniq();
+		$uniq->x -= $x;
+		$uniq->y -= $y;
+		$uniq->z -= $z;
+		return $uniq;
 	}
 
 	public function subtractVector(Vector3 $v) : Vector3{
-		return $this->add(-$v->x, -$v->y, -$v->z);
+		$uniq = thisuniq();
+		$uniq->x -= $v->x;
+		$uniq->y -= $v->y;
+		$uniq->z -= $v->z;
+		return $uniq;
 	}
 
 	public function multiply(float $number) : Vector3{
-		return new Vector3($this->x * $number, $this->y * $number, $this->z * $number);
+		$uniq = thisuniq();
+		$uniq->x *= $x;
+		$uniq->y *= $y;
+		$uniq->z *= $z;
+		return $uniq;
 	}
 
 	public function divide(float $number) : Vector3{
-		return new Vector3($this->x / $number, $this->y / $number, $this->z / $number);
+		$uniq = thisuniq();
+		$uniq->x /= $x;
+		$uniq->y /= $y;
+		$uniq->z /= $z;
+		return $uniq;
 	}
 
 	public function ceil() : Vector3{
-		return new Vector3((int) ceil($this->x), (int) ceil($this->y), (int) ceil($this->z));
+		$uniq = thisuniq();
+		$uniq->x = (int) ceil($uniq->x);
+		$uniq->y = (int) ceil($uniq->y);
+		$uniq->z = (int) ceil($uniq->z);
+		return $uniq;
 	}
 
 	public function floor() : Vector3{
-		return new Vector3((int) floor($this->x), (int) floor($this->y), (int) floor($this->z));
+		$uniq = thisuniq();
+		$uniq->x = (int) floor($uniq->x);
+		$uniq->y = (int) floor($uniq->y);
+		$uniq->z = (int) floor($uniq->z);
+		return $uniq;
 	}
 
 	public function round(int $precision = 0, int $mode = PHP_ROUND_HALF_UP) : Vector3{
-		return $precision > 0 ?
-			new Vector3(round($this->x, $precision, $mode), round($this->y, $precision, $mode), round($this->z, $precision, $mode)) :
-			new Vector3((int) round($this->x, $precision, $mode), (int) round($this->y, $precision, $mode), (int) round($this->z, $precision, $mode));
+		$uniq = thisuniq();
+		$uniq->x = round($uniq->x, $precision, $mode);
+		$uniq->y = round($uniq->y, $precision, $mode);
+		$uniq->z = round($uniq->z, $precision, $mode);
+		if($precision <= 0) {
+			$uniq->x = (int) $uniq->x;
+			$uniq->y = (int) $uniq->y;
+			$uniq->z = (int) $uniq->z;
+		}
+		return $uniq;
 	}
 
 	public function abs() : Vector3{
-		return new Vector3(abs($this->x), abs($this->y), abs($this->z));
+		$uniq = thisuniq();
+		$uniq->x = abs($uniq->x);
+		$uniq->y = abs($uniq->y);
+		$uniq->z = abs($uniq->z);
+		return $uniq;
 	}
 
 	/**
 	 * @return Vector3
 	 */
 	public function getSide(int $side, int $step = 1){
+		$uniq = thisuniq();
 		switch($side){
 			case Facing::DOWN:
-				return new Vector3($this->x, $this->y - $step, $this->z);
+				$uniq->y -= $step;
+				break;
 			case Facing::UP:
-				return new Vector3($this->x, $this->y + $step, $this->z);
+				$uniq->y += $step;
+				break;
 			case Facing::NORTH:
-				return new Vector3($this->x, $this->y, $this->z - $step);
+				$uniq->z -= $step;
+				break;
 			case Facing::SOUTH:
-				return new Vector3($this->x, $this->y, $this->z + $step);
+				$uniq->z += $step;
+				break;
 			case Facing::WEST:
-				return new Vector3($this->x - $step, $this->y, $this->z);
+				$uniq->x -= $step;
+				break;
 			case Facing::EAST:
-				return new Vector3($this->x + $step, $this->y, $this->z);
-			default:
-				return $this;
+				$uniq->x += $step;
+				break;
 		}
+		return $uniq;
 	}
 
 	/**
 	 * @return Vector3
 	 */
 	public function down(int $step = 1){
-		return $this->getSide(Facing::DOWN, $step);
+		$uniq = thisuniq();
+		$uniq->y -= $step;
+		return $uniq;
 	}
 
 	/**
 	 * @return Vector3
 	 */
 	public function up(int $step = 1){
-		return $this->getSide(Facing::UP, $step);
+		$uniq = thisuniq();
+		$uniq->y += $step;
+		return $uniq;
 	}
 
 	/**
 	 * @return Vector3
 	 */
 	public function north(int $step = 1){
-		return $this->getSide(Facing::NORTH, $step);
+		$uniq = thisuniq();
+		$uniq->z -= $step;
+		return $uniq;
 	}
 
 	/**
 	 * @return Vector3
 	 */
 	public function south(int $step = 1){
-		return $this->getSide(Facing::SOUTH, $step);
+		$uniq = thisuniq();
+		$uniq->z += $step;
+		return $uniq;
 	}
 
 	/**
 	 * @return Vector3
 	 */
 	public function west(int $step = 1){
-		return $this->getSide(Facing::WEST, $step);
+		$uniq = thisuniq();
+		$uniq->x -= $step;
+		return $uniq;
 	}
 
 	/**
 	 * @return Vector3
 	 */
 	public function east(int $step = 1){
-		return $this->getSide(Facing::EAST, $step);
+		$uniq = thisuniq();
+		$uniq->x += $step;
+		return $uniq;
 	}
 
 	/**
@@ -296,12 +357,19 @@ class Vector3{
 	}
 
 	public function normalize() : Vector3{
-		$len = $this->lengthSquared();
-		if($len > 0){
-			return $this->divide(sqrt($len));
+		$uniq = thisuniq();
+		$len2 = $uniq->lengthSquared();
+		if($len2 === 0.0) { // return type hint of `lengthSquared` guarantees $len2 is float
+			$uniq->x = 0;
+			$uniq->y = 0;
+			$uniq->z = 0;
+		} else {
+			$len = sqrt($len2);
+			$uniq->x /= $len;
+			$uniq->y /= $len;
+			$uniq->z /= $len;
 		}
-
-		return new Vector3(0, 0, 0);
+		return $uniq;
 	}
 
 	public function dot(Vector3 $v) : float{
@@ -309,11 +377,17 @@ class Vector3{
 	}
 
 	public function cross(Vector3 $v) : Vector3{
-		return new Vector3(
-			$this->y * $v->z - $this->z * $v->y,
-			$this->z * $v->x - $this->x * $v->z,
-			$this->x * $v->y - $this->y * $v->x
-		);
+		$uniq = thisuniq();
+
+		// clone properties first, may be overwritten
+		$x = $uniq->x;
+		$y = $uniq->y;
+		$z = $uniq->z;
+
+		$uniq->x = $y * $v->z - $z * $v->y;
+		$uniq->y = $z * $v->x - $x * $v->z;
+		$uniq->z = $x * $v->y - $y * $v->x;
+		return $uniq;
 	}
 
 	public function equals(Vector3 $v) : bool{
@@ -335,7 +409,11 @@ class Vector3{
 		if($f < 0 or $f > 1){
 			return null;
 		}else{
-			return new Vector3($x, $this->y + ($v->y - $this->y) * $f, $this->z + ($v->z - $this->z) * $f);
+			$uniq = thisuniq();
+			$uniq->x = $x;
+			$uniq->y += ($v->y - $uniq->y) * $f;
+			$uniq->z += ($v->z - $uniq->z) * $f;
+			return $uniq;
 		}
 	}
 
@@ -354,7 +432,11 @@ class Vector3{
 		if($f < 0 or $f > 1){
 			return null;
 		}else{
-			return new Vector3($this->x + ($v->x - $this->x) * $f, $y, $this->z + ($v->z - $this->z) * $f);
+			$uniq = thisuniq();
+			$uniq->x += ($v->x - $uniq->x) * $f;
+			$uniq->y = $y;
+			$uniq->z += ($v->z - $uniq->z) * $f;
+			return $uniq;
 		}
 	}
 
@@ -373,7 +455,11 @@ class Vector3{
 		if($f < 0 or $f > 1){
 			return null;
 		}else{
-			return new Vector3($this->x + ($v->x - $this->x) * $f, $this->y + ($v->y - $this->y) * $f, $z);
+			$uniq = thisuniq();
+			$uniq->x += ($v->x - $uniq->x) * $f;
+			$uniq->y += ($v->y - $uniq->y) * $f;
+			$uniq->z = $z;
+			return $uniq;
 		}
 	}
 

--- a/src/Vector3.php
+++ b/src/Vector3.php
@@ -103,7 +103,7 @@ class Vector3{
 	 * @param int|float $z
 	 */
 	public function add($x, $y, $z) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x += $x;
 		$uniq->y += $y;
 		$uniq->z += $z;
@@ -111,7 +111,7 @@ class Vector3{
 	}
 
 	public function addVector(Vector3 $v) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x += $v->x;
 		$uniq->y += $v->y;
 		$uniq->z += $v->z;
@@ -130,7 +130,7 @@ class Vector3{
 	 * @param int|float $z
 	 */
 	public function subtract($x, $y, $z) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x -= $x;
 		$uniq->y -= $y;
 		$uniq->z -= $z;
@@ -138,7 +138,7 @@ class Vector3{
 	}
 
 	public function subtractVector(Vector3 $v) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x -= $v->x;
 		$uniq->y -= $v->y;
 		$uniq->z -= $v->z;
@@ -146,7 +146,7 @@ class Vector3{
 	}
 
 	public function multiply(float $number) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x *= $x;
 		$uniq->y *= $y;
 		$uniq->z *= $z;
@@ -154,7 +154,7 @@ class Vector3{
 	}
 
 	public function divide(float $number) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x /= $x;
 		$uniq->y /= $y;
 		$uniq->z /= $z;
@@ -162,7 +162,7 @@ class Vector3{
 	}
 
 	public function ceil() : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x = (int) ceil($uniq->x);
 		$uniq->y = (int) ceil($uniq->y);
 		$uniq->z = (int) ceil($uniq->z);
@@ -170,7 +170,7 @@ class Vector3{
 	}
 
 	public function floor() : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x = (int) floor($uniq->x);
 		$uniq->y = (int) floor($uniq->y);
 		$uniq->z = (int) floor($uniq->z);
@@ -178,7 +178,7 @@ class Vector3{
 	}
 
 	public function round(int $precision = 0, int $mode = PHP_ROUND_HALF_UP) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x = round($uniq->x, $precision, $mode);
 		$uniq->y = round($uniq->y, $precision, $mode);
 		$uniq->z = round($uniq->z, $precision, $mode);
@@ -191,7 +191,7 @@ class Vector3{
 	}
 
 	public function abs() : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x = abs($uniq->x);
 		$uniq->y = abs($uniq->y);
 		$uniq->z = abs($uniq->z);
@@ -202,7 +202,7 @@ class Vector3{
 	 * @return Vector3
 	 */
 	public function getSide(int $side, int $step = 1){
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		switch($side){
 			case Facing::DOWN:
 				$uniq->y -= $step;
@@ -230,7 +230,7 @@ class Vector3{
 	 * @return Vector3
 	 */
 	public function down(int $step = 1){
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->y -= $step;
 		return $uniq;
 	}
@@ -239,7 +239,7 @@ class Vector3{
 	 * @return Vector3
 	 */
 	public function up(int $step = 1){
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->y += $step;
 		return $uniq;
 	}
@@ -248,7 +248,7 @@ class Vector3{
 	 * @return Vector3
 	 */
 	public function north(int $step = 1){
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->z -= $step;
 		return $uniq;
 	}
@@ -257,7 +257,7 @@ class Vector3{
 	 * @return Vector3
 	 */
 	public function south(int $step = 1){
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->z += $step;
 		return $uniq;
 	}
@@ -266,7 +266,7 @@ class Vector3{
 	 * @return Vector3
 	 */
 	public function west(int $step = 1){
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x -= $step;
 		return $uniq;
 	}
@@ -275,7 +275,7 @@ class Vector3{
 	 * @return Vector3
 	 */
 	public function east(int $step = 1){
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$uniq->x += $step;
 		return $uniq;
 	}
@@ -357,7 +357,7 @@ class Vector3{
 	}
 
 	public function normalize() : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 		$len2 = $uniq->lengthSquared();
 		if($len2 === 0.0) { // return type hint of `lengthSquared` guarantees $len2 is float
 			$uniq->x = 0;
@@ -377,7 +377,7 @@ class Vector3{
 	}
 
 	public function cross(Vector3 $v) : Vector3{
-		$uniq = thisuniq();
+		$uniq = thisrc() === 1 ? $this : clone $this;
 
 		// clone properties first, may be overwritten
 		$x = $uniq->x;
@@ -409,7 +409,7 @@ class Vector3{
 		if($f < 0 or $f > 1){
 			return null;
 		}else{
-			$uniq = thisuniq();
+			$uniq = thisrc() === 1 ? $this : clone $this;
 			$uniq->x = $x;
 			$uniq->y += ($v->y - $uniq->y) * $f;
 			$uniq->z += ($v->z - $uniq->z) * $f;
@@ -432,7 +432,7 @@ class Vector3{
 		if($f < 0 or $f > 1){
 			return null;
 		}else{
-			$uniq = thisuniq();
+			$uniq = thisrc() === 1 ? $this : clone $this;
 			$uniq->x += ($v->x - $uniq->x) * $f;
 			$uniq->y = $y;
 			$uniq->z += ($v->z - $uniq->z) * $f;
@@ -455,7 +455,7 @@ class Vector3{
 		if($f < 0 or $f > 1){
 			return null;
 		}else{
-			$uniq = thisuniq();
+			$uniq = thisrc() === 1 ? $this : clone $this;
 			$uniq->x += ($v->x - $uniq->x) * $f;
 			$uniq->y += ($v->y - $uniq->y) * $f;
 			$uniq->z = $z;


### PR DESCRIPTION
This pull request optimizes unique-reference calls to Vector3, which minimizes object allocations for long call chains like this:
```php
$vector
  ->add(1, 2, 3)
  ->multiply(3)
  ->cross($otherVector)
  ->divide(4)
```

For the above code, the current implementation requires 4 allocations, while with this patch only one allocation is required.

## Adaptability
This patch is not effective when the vector is referenced by *any* variables, including `$this`.
This means not even calling `$this->xxx()` from a subclass of `Vector3` would utilize this optimization,
nor `$foo->xxx()` (even if `$foo` is no longer used).

This patch is not effective in *some* chain calls. For example, this does not optimize anything in `$event->getPlayer()->add()`.

## Drawbacks
This requires users to install ext-thisrc. A polyfill or cpp-based alternative may be used to support non-thisrc users.

This involves extra function call overhead in the `thisrc()` calls. ext-thisrc may be implemented at a lower level of PHP internals (rather than just as a `PHP_FUNCTION`) may be useful, but that would be much more challenging.

## Tasks
- [x] Adopt thisrc in `Vector3`
- [ ] Adopt thisrc in `Vector2`
- [ ] Implement polyfill for users without ext-thisrc installed
- [ ] Perform benchmarks to contrast the overhead of `thisrc()` against overhead of cloning. In particular, benchmark this in PocketMine, where not too many Vector3 calls are chained, to see if this makes anything *worse*.
- [ ] Fix travis builds