### PR TITLE
Add exception in Math::solveQuadratic() method

### DIFF
--- a/src/Math.php
+++ b/src/Math.php
@@ -52,6 +52,9 @@ abstract class Math{
 	 * @return float[]
 	 */
 	public static function solveQuadratic(float $a, float $b, float $c) : array{
+		if($a === 0){
+			throw new Exception("Coefficient a cannot be 0!");
+		}
 		$discriminant = $b ** 2 - 4 * $a * $c;
 		if($discriminant > 0){ //2 real roots
 			$sqrtDiscriminant = sqrt($discriminant);

--- a/src/Math.php
+++ b/src/Math.php
@@ -52,7 +52,7 @@ abstract class Math{
 	 * @return float[]
 	 */
 	public static function solveQuadratic(float $a, float $b, float $c) : array{
-		if($a === (float) 0){
+		if($a === 0.0){
 			throw new \InvalidArgumentException("Coefficient a cannot be 0!");
 		}
 		$discriminant = $b ** 2 - 4 * $a * $c;

--- a/src/Math.php
+++ b/src/Math.php
@@ -52,7 +52,7 @@ abstract class Math{
 	 * @return float[]
 	 */
 	public static function solveQuadratic(float $a, float $b, float $c) : array{
-		if($a === 0){
+		if((int) $a === 0){
 			throw new Exception("Coefficient a cannot be 0!");
 		}
 		$discriminant = $b ** 2 - 4 * $a * $c;

--- a/src/Math.php
+++ b/src/Math.php
@@ -52,8 +52,8 @@ abstract class Math{
 	 * @return float[]
 	 */
 	public static function solveQuadratic(float $a, float $b, float $c) : array{
-		if((int) $a === 0){
-			throw new \Exception("Coefficient a cannot be 0!");
+		if($a === (float) 0){
+			throw new \InvalidArgumentException("Coefficient a cannot be 0!");
 		}
 		$discriminant = $b ** 2 - 4 * $a * $c;
 		if($discriminant > 0){ //2 real roots

--- a/src/Math.php
+++ b/src/Math.php
@@ -53,7 +53,7 @@ abstract class Math{
 	 */
 	public static function solveQuadratic(float $a, float $b, float $c) : array{
 		if((int) $a === 0){
-			throw new Exception("Coefficient a cannot be 0!");
+			throw new \Exception("Coefficient a cannot be 0!");
 		}
 		$discriminant = $b ** 2 - 4 * $a * $c;
 		if($discriminant > 0){ //2 real roots


### PR DESCRIPTION
## Introduction

The `Math::solveQuadratic()` method accepts parameter $a with the value 0, thus causing it to return array with invalid values (INF, NAN) if $discriminant equal to or larger than 0. Parameter $a should not pass the value 0, because in quadratic equation, coefficient a must not be 0.

## Changes

Added an exception in `Math::solveQuadratic()` method which will be thrown if parameter $a passes the value 0.

## Tests

Before adding exception:
![image](https://user-images.githubusercontent.com/68368066/112335241-085c2780-8cf7-11eb-8fa1-ed29c6c364bd.png)

After adding exception:
![image](https://user-images.githubusercontent.com/68368066/112336611-2fffbf80-8cf8-11eb-8617-4f62b45b6f26.png)
