### PR TITLE
AxisAlignedBB: added method to shift it along a given direction

### DIFF
--- a/src/AxisAlignedBB.php
+++ b/src/AxisAlignedBB.php
@@ -232,13 +232,11 @@ class AxisAlignedBB{
 	 * @throws \InvalidArgumentException
 	 */
 	public function shift(int $face, float $distance) : AxisAlignedBB{
-		return match($face){
-			Facing::DOWN => $this->offset(0, -$distance, 0),
-			Facing::UP => $this->offset(0, $distance, 0),
-			Facing::NORTH => $this->offset(0, 0, -$distance),
-			Facing::SOUTH => $this->offset(0, 0, $distance),
-			Facing::WEST => $this->offset(-$distance, 0, 0),
-			Facing::EAST => $this->offset($distance, 0, 0),
+		$distance *= Facing::isPositive($face) ? 1 : -1;
+		return match(Facing::axis($face)){
+			Axis::Y => $this->offset(0, $distance, 0),
+			Axis::Z => $this->offset(0, 0, $distance),
+			Axis::X => $this->offset($distance, 0, 0),
 			default => throw new \InvalidArgumentException("Invalid face $face")
 		};
 	}

--- a/src/AxisAlignedBB.php
+++ b/src/AxisAlignedBB.php
@@ -225,7 +225,6 @@ class AxisAlignedBB{
 
 	/**
 	 * Shifts the AABB in the given direction.
-	 * @see AxisAlignedBB::extend()
 	 *
 	 * @param float $distance Positive values shift the AABB in the given direction, negative values in the opposite.
 	 *
@@ -233,7 +232,15 @@ class AxisAlignedBB{
 	 * @throws \InvalidArgumentException
 	 */
 	public function shift(int $face, float $distance) : AxisAlignedBB{
-		return $this->extend($face, $distance)->extend(Facing::opposite($face), -$distance);
+		return match($face){
+			Facing::DOWN => $this->offset(0, -$distance, 0),
+			Facing::UP => $this->offset(0, $distance, 0),
+			Facing::NORTH => $this->offset(0, 0, -$distance),
+			Facing::SOUTH => $this->offset(0, 0, $distance),
+			Facing::WEST => $this->offset(-$distance, 0, 0),
+			Facing::EAST => $this->offset($distance, 0, 0),
+			default => throw new \InvalidArgumentException("Invalid face $face")
+		};
 	}
 
 	/**

--- a/src/AxisAlignedBB.php
+++ b/src/AxisAlignedBB.php
@@ -224,6 +224,29 @@ class AxisAlignedBB{
 	}
 
 	/**
+	 * Shifts the AABB in the given direction.
+	 * @see AxisAlignedBB::extend()
+	 *
+	 * @param float $distance Positive values shift the AABB in the given direction, negative values in the opposite.
+	 *
+	 * @return $this
+	 * @throws \InvalidArgumentException
+	 */
+	public function shift(int $face, float $distance) : AxisAlignedBB{
+		return $this->extend($face, $distance)->extend(Facing::opposite($face), -$distance);
+	}
+
+	/**
+	 * Shifts a clone of the AABB in the given direction.
+	 * @see AxisAlignedBB::shift()
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function shiftedCopy(int $face, float $distance) : AxisAlignedBB{
+		return (clone $this)->shift($face, $distance);
+	}
+
+	/**
 	 * Increases the dimension of the AABB along the given axis.
 	 *
 	 * @param int   $axis one of the Axis::* constants


### PR DESCRIPTION
## Explanation
As explained in https://github.com/pmmp/Math/issues/63, there is currently no easy way to shift an AxisAlignedBB along a given direction. Instead, that must be done with `AxisAlignedBB::offset()` which forces developers to make their own checks to determine the axis, based on the direction, the AABB should be shifted along, as done in https://github.com/pmmp/PocketMine-MP/blob/ad56392d959e9d4eefb1cdae4bc659eac7ae2e1f/src/block/Skull.php#L128-L132.

## API changes
- Added method ` AxisAlignedBB::shift(Facing, int) : AxisAlignedBB` which shifts the AABB in the given direction.
- Added method ` AxisAlignedBB::shiftedCopy(Facing, int) : AxisAlignedBB` which shifts a clone of the AABB in the given direction.